### PR TITLE
Remove stub tag, only show stub warning if less than 5 tags

### DIFF
--- a/mygamelist/games/views.py
+++ b/mygamelist/games/views.py
@@ -245,7 +245,7 @@ def GameView(request, game_id, name=None):
     user_collections = Collection.objects.filter(category=user_col_type).filter(games=game).order_by('category', 'name')
 
     stubbed = False
-    if "STUB" in [x.name for x in game.tags.all()]:
+    if len(game.tags.all()) < 5:
         stubbed = True
 
     game_entries = UserGameListEntry.objects.filter(game=game)


### PR DESCRIPTION
This involved several database changes as well as changes to the staff tools for bringing in data.